### PR TITLE
implement logger in rust

### DIFF
--- a/rust-examples/logger.rs
+++ b/rust-examples/logger.rs
@@ -1,0 +1,29 @@
+// This stub file contains items that aren't used yet; feel free to remove this module attribute
+// to enable stricter warnings.
+#![allow(unused)]
+
+/// various log levels
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum LogLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+/// primary function for emitting logs
+pub fn log(level: LogLevel, message: &str) -> String {
+    match level {
+        LogLevel::Info => format!("[INFO]: {}", message),
+        LogLevel::Warning => format!("[WARNING]: {}", message),
+        LogLevel::Error => format!("[ERROR]: {}", message),
+    }
+}
+pub fn info(message: &str) -> String {
+    log(LogLevel::Info, message)
+}
+pub fn warn(message: &str) -> String {
+    log(LogLevel::Warning, message)
+}
+pub fn error(message: &str) -> String {
+    log(LogLevel::Error, message)
+}


### PR DESCRIPTION
While writing code loggers are quite important for any type of application like CLI, webapp or any other. This PR attempts to demonstrate some basic logger implementation in rust language.